### PR TITLE
Fix resize for columns with initially configured width.

### DIFF
--- a/libs/datatable/src/components/table/table.component.ts
+++ b/libs/datatable/src/components/table/table.component.ts
@@ -382,11 +382,11 @@ export class DataTableComponent implements DataTableParams, OnInit, AfterContent
 
   private resizeColumnStart(event: MouseEvent, column: DataTableColumnDirective, columnElement: HTMLElement) {
     this._resizeInProgress = true;
-
+    let startOffset = columnElement.offsetWidth - event.pageX;
     drag(event, {
       move: (moveEvent: MouseEvent, dx: number) => {
         if (this._isResizeInLimit(columnElement, dx)) {
-          column.width = columnElement.offsetWidth + dx;
+          column.width = startOffset + moveEvent.pageX + dx;
         }
       },
     });


### PR DESCRIPTION
**Description:**
In the case when columns were defined initially width with the attribute [width], the resize of the first resizable column will work unexpectedly.
Current fix correcting resizeColumnStart function.

